### PR TITLE
SFDP-47 Add quality gate metrics to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 # fcp-sfd-comms
+![Publish](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) 
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
+
 Communications service for the Single Front Door.
 
 This service is part of the [Single Front Door (SFD) service](https://github.com/DEFRA/fcp-sfd-core).
@@ -7,12 +12,6 @@ This service is part of the [Single Front Door (SFD) service](https://github.com
 - Docker
 - Docker Compose
 - Node.js (v22 LTS)
-
-## Code Quality Metrics
-![Publish](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) 
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
 
 ## Setup
 | Name                      | Default Value                                          | Required                  | Description                                                                 |

--- a/README.md
+++ b/README.md
@@ -9,14 +9,10 @@ This service is part of the [Single Front Door (SFD) service](https://github.com
 - Node.js (v22 LTS)
 
 ## Code Quality Metrics
-| Metric | Badge |
-| ------ | ----- |
-| Publish | ![Publish](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg) |
-| Quality Gate | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
-| Bugs | [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=bugs)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
-| Code Smells | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
-| Duplicated Lines | [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
-| Coverage | [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+![Publish](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) 
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms)
 
 ## Setup
 | Name                      | Default Value                                          | Required                  | Description                                                                 |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This service is part of the [Single Front Door (SFD) service](https://github.com
 - Docker Compose
 - Node.js (v22 LTS)
 
+## Code Quality Metrics
+| Metric | Badge |
+| ------ | ----- |
+| Publish | ![Build](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg) |
+| Quality Gate | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+| Bugs | [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=bugs)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+| Code Smells | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+| Duplicated Lines | [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=duplicated_lines_density)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+| Coverage | [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=coverage)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
+
 ## Setup
 | Name                      | Default Value                                          | Required                  | Description                                                                 |
 |---------------------------|--------------------------------------------------------|---------------------------|-----------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This service is part of the [Single Front Door (SFD) service](https://github.com
 ## Code Quality Metrics
 | Metric | Badge |
 | ------ | ----- |
-| Publish | ![Build](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg) |
+| Publish | ![Publish](https://github.com/defra/fcp-sfd-comms/actions/workflows/publish.yml/badge.svg) |
 | Quality Gate | [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
 | Bugs | [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=bugs)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |
 | Code Smells | [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_fcp-sfd-comms&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=DEFRA_fcp-sfd-comms) |


### PR DESCRIPTION
Ticket - https://eaflood.atlassian.net/browse/SFDP-47

The presentation of code quality metrics on this PR is inspired by the `README` on the [fcp-defra-id-example](https://github.com/defra/fcp-defra-id-example?tab=readme-ov-file#fcp-defra-identity-example) repo (shoutout @johnwatson484). Like the Defra ID example repo I have added badges covering multiple code quality metrics as well as the Github workflow badge to show the `publish` workflow is passing when PRs are merged to the `main` branch. Once this PR is approved I will update the equivalent tech debt tickets for `fcp-sfd-data` ([SFDP-311](https://eaflood.atlassian.net/browse/SFDP-311)) and `fcp-sfd-frontend` ([SFDP-312](https://eaflood.atlassian.net/browse/SFDP-312)) with a comment describing what layout was agreed on this PR so that the same can be done for the other two tickets. This way the `README` files will be consistent across SFD repos.


[SFDP-311]: https://eaflood.atlassian.net/browse/SFDP-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SFDP-312]: https://eaflood.atlassian.net/browse/SFDP-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ