### PR TITLE
SFDP-406 - Remove Heartbeat / Visibility Timeout Adjust

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fcp-sfd-comms",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Comms Service for Single Front Door",
   "main": "src/index.js",
   "type": "module",

--- a/src/config/messaging.js
+++ b/src/config/messaging.js
@@ -18,18 +18,6 @@ export const messagingConfig = {
       default: 0,
       env: 'SQS_CONSUMER_POLLING_WAIT_TIME'
     },
-    visibilityTimeout: {
-      doc: 'The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request',
-      format: Number,
-      default: 30,
-      env: 'SQS_CONSUMER_VISIBILITY_TIMEOUT'
-    },
-    heartbeatInterval: {
-      doc: 'The interval (in seconds) between requests to extend the message visibility timeout. Must be less than the visibility timeout',
-      format: Number,
-      default: 5,
-      env: 'SQS_CONSUMER_HEARTBEAT_INTERVAL'
-    },
     commsRequest: {
       queueUrl: {
         doc: 'URL for the comms ingest queue',

--- a/src/messaging/inbound/comms-request/consumer.js
+++ b/src/messaging/inbound/comms-request/consumer.js
@@ -12,8 +12,6 @@ const startCommsListener = (sqsClient) => {
   commsRequestConsumer = Consumer.create({
     queueUrl: config.get('messaging.commsRequest.queueUrl'),
     batchSize: config.get('messaging.batchSize'),
-    visibilityTimeout: config.get('messaging.visibilityTimeout'),
-    heartbeatInterval: config.get('messaging.heartbeatInterval'),
     waitTimeSeconds: config.get('messaging.waitTimeSeconds'),
     pollingWaitTime: config.get('messaging.pollingWaitTime'),
     handleMessageBatch: async (messages) => handleCommRequestMessages(messages),


### PR DESCRIPTION
# Description

https://eaflood.atlassian.net/browse/SFDP-305

Removed heartbeat and visibility timeout from SQS consumer setup. CDP currently don't assign permissions to adjust the visibility timeout which results in an error. Not much of an issue as the default visibility timeout is 30 seconds, but could be a problem if we have longer running processes in the future.

## Checklist

- [ ] has cloned repo locally
- [ ] has successfully run service
- [ ] has verified all ACs covered by tests
- [ ] has verified PR branch deploys correctly
- [ ] have verified all tests pass
- [ ] have checked README has been updated
- [ ] has verified code is maintable
- [ ] has suggested refactoring opportunities or simplification
- [ ] has challenged complexity
