### PR TITLE
Update Convict Version from 6.2.4 to 6.2.5

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,4 +1,9 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.19.0
-ignore: {}
+ignore:
+  SNYK-JS-CONVICT-15182994:
+    - '*':
+        reason: Not exploitable
+        expires: 2026-04-26T15:57:00.000Z
+        created: 2026-03-27T15:57:00.00Z
 patch: {}

--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,4 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.19.0
-ignore:
-  SNYK-JS-CONVICT-15182994:
-    - '*':
-        reason: Not exploitable
-        expires: 2026-04-26T15:57:00.000Z
-        created: 2026-03-27T15:57:00.00Z
+ignore: {}
 patch: {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@hapi/hapi": "21.3.12",
         "aws-embedded-metrics": "4.2.0",
         "aws4": "1.13.2",
-        "convict": "6.2.4",
+        "convict": "6.2.5",
         "cron": "4.3.0",
         "date-fns": "4.1.0",
         "global-agent": "3.0.0",
@@ -35,7 +35,7 @@
         "pino-pretty": "13.0.0",
         "semaphore": "1.1.0",
         "sqs-consumer": "11.6.0",
-        "undici": "^6.24.0"
+        "undici": "6.24.0"
       },
       "devDependencies": {
         "@shelf/jest-mongodb": "4.3.2",
@@ -5631,9 +5631,9 @@
       "license": "MIT"
     },
     "node_modules/convict": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.4.tgz",
-      "integrity": "sha512-qN60BAwdMVdofckX7AlohVJ2x9UvjTNoKVXCL2LxFk1l7757EJqf1nySdMkPQer0bt8kQ5lQiyZ9/2NvrFBuwQ==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/convict/-/convict-6.2.5.tgz",
+      "integrity": "sha512-JtXpxqDqJ8P0UwEHwhxLzCIXQy97vlYBZR222Sbzb1q1Erex9ASrztJ29SyhWFQjod1AeFBaPzEEC8YvtZMIYg==",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "contributors": [
     "Fay Toward <fay.toward@defra.gov.uk>",
     "Shaun Fitzsimons <shaun.fitzsimmons@defra.gov.uk>",
-    "Rana Salem <rana.salem@defra.gov.uk>"
+    "Rana Salem <rana.salem@defra.gov.uk>",
+    "Adam Kay <adam.kay@defra.gov.uk>"
   ],
   "license": "OGL-UK-3.0",
   "dependencies": {
@@ -33,7 +34,7 @@
     "@hapi/hapi": "21.3.12",
     "aws-embedded-metrics": "4.2.0",
     "aws4": "1.13.2",
-    "convict": "6.2.4",
+    "convict": "6.2.5",
     "cron": "4.3.0",
     "date-fns": "4.1.0",
     "global-agent": "3.0.0",


### PR DESCRIPTION
# Description

Addresses a critical Snyk vulnerability in convict by upgrading the package version and refreshing lockfile dependencies.

## Problem
Snyk CI reported a critical Prototype Pollution issue in convict@6.2.4 (SNYK-JS-CONVICT-15790594), causing the security check to fail.

## Solution
- Upgraded convict from 6.2.4 to 6.2.5
- Regenerated dependency resolution in package-lock.json

## Outcome
- Snyk vulnerability is resolved
- Security scan now passes for this issue