### PR TITLE
Align docker compose file with sfd services

### DIFF
--- a/compose.override.yaml
+++ b/compose.override.yaml
@@ -1,4 +1,4 @@
-name: fcp-sfd-comms
+name: fcp-sfd
 services:
   fcp-sfd-comms:
     ports:


### PR DESCRIPTION
As part of the tech debt cleanup, we are aligning the docker compose files within the sfd services. This is to enable us to spin up all the containers with a single command and have non of the services clashing on ports.

